### PR TITLE
Updates to UiChild parsing

### DIFF
--- a/gwt-uibinder-example/gwt-uibinder-example-client/src/main/java/org/gwtproject/uibinder/example/ioc/TestBedModule.java
+++ b/gwt-uibinder-example/gwt-uibinder-example-client/src/main/java/org/gwtproject/uibinder/example/ioc/TestBedModule.java
@@ -20,9 +20,11 @@ import org.gwtproject.uibinder.example.view.HomeView;
 import org.gwtproject.uibinder.example.view.OldVsNewComparisonView;
 import org.gwtproject.uibinder.example.view.Shell;
 import org.gwtproject.uibinder.example.view.SupplementalView;
+import org.gwtproject.uibinder.example.view.UiChildTestView;
 import org.gwtproject.uibinder.example.view.impl.HomeViewImpl;
 import org.gwtproject.uibinder.example.view.impl.ShellImpl;
 import org.gwtproject.uibinder.example.view.impl.SupplementalViewImpl;
+import org.gwtproject.uibinder.example.view.impl.UiChildTestViewImpl;
 
 import com.google.gwt.user.client.ui.IsWidget;
 
@@ -49,12 +51,14 @@ public abstract class TestBedModule {
   static Map<Token, Provider<? extends IsWidget>> provideNavigationMapping(
       Provider<HomeView> homeViewProvider,
       Provider<OldVsNewComparisonView> oldVsNewComparisonViewProvider,
+      Provider<UiChildTestView> uiChildTestViewProvider,
       Provider<SupplementalView> supplementalViewProvider) {
     Map<Token, Provider<? extends IsWidget>> navMap = new LinkedHashMap<>();
 
     navMap.put(Token.DEFAULT, homeViewProvider);
     navMap.put(Token.create("simpleCompare", "Old Vs New Comparison"),
         oldVsNewComparisonViewProvider);
+    navMap.put(Token.create("uichild", "UiChild Test"), uiChildTestViewProvider);
     navMap.put(Token.create("supplemental", "Supplemental View"), supplementalViewProvider);
 
     return navMap;
@@ -65,6 +69,9 @@ public abstract class TestBedModule {
 
   @Binds
   abstract HomeView homeView(HomeViewImpl homeView);
+
+  @Binds
+  abstract UiChildTestView uiChildTestView(UiChildTestViewImpl impl);
 
   @Binds
   abstract SupplementalView supplementalView(SupplementalViewImpl impl);

--- a/gwt-uibinder-example/gwt-uibinder-example-client/src/main/java/org/gwtproject/uibinder/example/view/UiChildTestView.java
+++ b/gwt-uibinder-example/gwt-uibinder-example-client/src/main/java/org/gwtproject/uibinder/example/view/UiChildTestView.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 Vertispan LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.gwtproject.uibinder.example.view;
+
+import com.google.gwt.user.client.ui.IsWidget;
+
+/**
+ *
+ */
+public interface UiChildTestView extends IsWidget {
+}

--- a/gwt-uibinder-example/gwt-uibinder-example-client/src/main/java/org/gwtproject/uibinder/example/view/impl/UiChildTestViewImpl.java
+++ b/gwt-uibinder-example/gwt-uibinder-example-client/src/main/java/org/gwtproject/uibinder/example/view/impl/UiChildTestViewImpl.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Vertispan LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.gwtproject.uibinder.example.view.impl;
+
+import org.gwtproject.uibinder.client.UiBinder;
+import org.gwtproject.uibinder.client.UiChild;
+import org.gwtproject.uibinder.client.UiTemplate;
+import org.gwtproject.uibinder.example.view.UiChildTestView;
+
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.Style.BorderStyle;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Widget;
+
+import javax.inject.Inject;
+
+/**
+ *
+ */
+public class UiChildTestViewImpl implements UiChildTestView {
+
+  @UiTemplate
+  interface MyUiBinder extends UiBinder<Widget, UiChildTestViewImpl> {
+  }
+
+  private MyUiBinder uiBinder = new UiChildTestViewImpl_MyUiBinderImpl();
+
+  private Widget widget;
+
+  @Inject
+  public UiChildTestViewImpl() {
+  }
+
+  @Override
+  public Widget asWidget() {
+    if (widget == null) {
+      widget = uiBinder.createAndBindUi(this);
+    }
+    return widget;
+  }
+
+  /**
+   * Custom Widget class to demonstrate @UiChild.
+   */
+  public static final class MyCustomWidget implements IsWidget {
+    private HorizontalPanel container = new HorizontalPanel();
+    // using label to know if we've initialized
+    private Label label;
+
+    @Override
+    public Widget asWidget() {
+      if (label == null) {
+        Style style = container.getElement().getStyle();
+        style.setBorderWidth(1, Unit.PX);
+        style.setBorderStyle(BorderStyle.SOLID);
+        style.setBorderColor("red");
+        style.setMarginTop(25, Unit.PX);
+
+        label = new Label("Custom Child Widget:");
+        container.insert(label, 0);
+      }
+      return container;
+    }
+
+    @UiChild(tagname = "customchild")
+    public void addCustomChild(Widget childWidget) {
+      container.add(childWidget);
+    }
+  }
+}

--- a/gwt-uibinder-example/gwt-uibinder-example-client/src/main/resources/org/gwtproject/uibinder/example/view/impl/UiChildTestViewImpl.ui.xml
+++ b/gwt-uibinder-example/gwt-uibinder-example-client/src/main/resources/org/gwtproject/uibinder/example/view/impl/UiChildTestViewImpl.ui.xml
@@ -2,7 +2,18 @@
 <ui:UiBinder
   xmlns:ui='urn:ui:com.google.gwt.uibinder'
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
+  xmlns:e="urn:import:com.google.gwt.editor.ui.client"
   xmlns:custom="urn:import:org.gwtproject.uibinder.example.view.impl.UiChildTestViewImpl">
+
+  <ui:style>
+    .deco {
+      margin-top: 25px;
+    }
+
+    .deco:before {
+      content: "ValueBoxEditorDecorator";
+    }
+  </ui:style>
 
   <g:VerticalPanel>
     <g:Label text="Vertical Panel with widgets"/>
@@ -11,6 +22,11 @@
         <g:Button text="button inside custom widget"/>
       </custom:customchild>
     </custom:MyCustomWidget>
+    <e:ValueBoxEditorDecorator addStyleNames="{style.deco}">
+      <e:valuebox>
+        <g:TextBox width="200px"/>
+      </e:valuebox>
+    </e:ValueBoxEditorDecorator>
   </g:VerticalPanel>
 
 </ui:UiBinder>

--- a/gwt-uibinder-example/gwt-uibinder-example-client/src/main/resources/org/gwtproject/uibinder/example/view/impl/UiChildTestViewImpl.ui.xml
+++ b/gwt-uibinder-example/gwt-uibinder-example-client/src/main/resources/org/gwtproject/uibinder/example/view/impl/UiChildTestViewImpl.ui.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder
+  xmlns:ui='urn:ui:com.google.gwt.uibinder'
+  xmlns:g="urn:import:com.google.gwt.user.client.ui"
+  xmlns:custom="urn:import:org.gwtproject.uibinder.example.view.impl.UiChildTestViewImpl">
+
+  <g:VerticalPanel>
+    <g:Label text="Vertical Panel with widgets"/>
+    <custom:MyCustomWidget>
+      <custom:customchild>
+        <g:Button text="button inside custom widget"/>
+      </custom:customchild>
+    </custom:MyCustomWidget>
+  </g:VerticalPanel>
+
+</ui:UiBinder>

--- a/gwt-uibinder-example/gwt-uibinder-example-client/src/main/resources/org/gwtproject/uibinder/example/view/impl/UiChildTestViewImpl.ui.xml
+++ b/gwt-uibinder-example/gwt-uibinder-example-client/src/main/resources/org/gwtproject/uibinder/example/view/impl/UiChildTestViewImpl.ui.xml
@@ -24,7 +24,7 @@
     </custom:MyCustomWidget>
     <e:ValueBoxEditorDecorator addStyleNames="{style.deco}">
       <e:valuebox>
-        <g:TextBox width="200px"/>
+        <g:TextBox value="Legacy @UiChild TextBox" width="200px"/>
       </e:valuebox>
     </e:ValueBoxEditorDecorator>
   </g:VerticalPanel>

--- a/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/AptUtil.java
+++ b/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/AptUtil.java
@@ -461,6 +461,20 @@ public class AptUtil {
     return false;
   }
 
+  /**
+   * Determines if TypeMirror is a raw type (outcome of erasure).
+   */
+  public static boolean isRaw(TypeMirror mirror) {
+    if (TypeKind.DECLARED.equals(mirror.getKind())) {
+      DeclaredType declaredType = (DeclaredType) mirror;
+      if (declaredType.getTypeArguments().isEmpty()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   public static boolean isSameType(DeclaredType declaredType, String canonicalName) {
     if (declaredType == null) {
       return false;

--- a/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/AptUtil.java
+++ b/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/AptUtil.java
@@ -111,9 +111,17 @@ public class AptUtil {
 
     Map<String, AnnotationValue> values = new HashMap<>();
 
+    // get details from real annotation (defaults)
+    List<ExecutableElement> annotationAttributes = ElementFilter
+        .methodsIn(annotationMirror.getAnnotationType().asElement().getEnclosedElements());
+    for (ExecutableElement annotationAttribute : annotationAttributes) {
+      values.put(annotationAttribute.getSimpleName().toString(),
+          annotationAttribute.getDefaultValue());
+    }
+
+    // get the set values set on the annotationMirror
     for (Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : annotationMirror
         .getElementValues().entrySet()) {
-
       values.put(entry.getKey().getSimpleName().toString(), entry.getValue());
     }
     return values;

--- a/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/BaseProcessor.java
+++ b/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/BaseProcessor.java
@@ -47,7 +47,7 @@ public abstract class BaseProcessor extends AbstractProcessor {
         return true;
       }
     } catch (Exception e) {
-      logger.log(Kind.NOTE, "Error Processing Annotation", e);
+      logger.log(Kind.ERROR, "Error Processing Annotation", e);
       return false;
     } finally {
       AptUtil.setProcessingEnvironment(null);

--- a/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/FieldReference.java
+++ b/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/FieldReference.java
@@ -52,8 +52,7 @@ public class FieldReference {
       } else if (i > 0) {
         b.append(", ");
       }
-
-      b.append(AptUtil.asTypeElement(types[i]).getQualifiedName().toString());
+      b.append(AptUtil.getParameterizedQualifiedSourceName(types[i]));
     }
 
     return b.toString();

--- a/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/GwtResourceEntityResolver.java
+++ b/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/GwtResourceEntityResolver.java
@@ -49,7 +49,7 @@ public class GwtResourceEntityResolver implements EntityResolver {
           "http://dl.google.com/gwt/DTD/", "https://dl-ssl.google.com/gwt/DTD/"
       }).collect(toSet()));
 
-  private static final String RESOURCES = "org/gwtproject/uibinder/resources/";
+  private static final String RESOURCES = "org.gwtproject.uibinder.resources";
 
   private final String pathBase;
 
@@ -72,7 +72,7 @@ public class GwtResourceEntityResolver implements EntityResolver {
 
       try {
         resource = processingEnvironment.getFiler()
-            .getResource(StandardLocation.CLASS_OUTPUT, RESOURCES,
+            .getResource(StandardLocation.CLASS_PATH, RESOURCES,
                 systemId.substring(matchingPrefix.length()));
       } catch (IOException e) {
         // empty catch

--- a/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/UiBinderClasses.java
+++ b/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/UiBinderClasses.java
@@ -29,4 +29,11 @@ public interface UiBinderClasses {
   String UIFACTORY = "org.gwtproject.uibinder.client.UiFactory";
   String UIHANDLER = "org.gwtproject.uibinder.client.UiHandler";
   String LAZYDOMELEMENT = "org.gwtproject.uibinder.client.LazyDomElement";
+
+  /**
+   * Legacy class names.
+   */
+  interface Legacy {
+    String UICHILD = "com.google.gwt.uibinder.client.UiChild";
+  }
 }

--- a/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/UiBinderWriter.java
+++ b/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/UiBinderWriter.java
@@ -506,7 +506,8 @@ public class UiBinderWriter {
 
   /**
    * Declare a field that will hold an Element instance. Returns a token that the caller must set as
-   * the id attribute of that element in whatever innerHTML expression will reproduce it at runtime.
+   * the id attribute of that element in whatever innerHTML expression will reproduce it at
+   * runtime.
    * <P> In the generated code, this token will be replaced by an expression to generate a unique
    * dom id at runtime. Further code will be generated to be run after widgets are instantiated, to
    * use that dom id in a getElementById call and assign the Element instance to its field.
@@ -831,6 +832,7 @@ public class UiBinderWriter {
           return false;
         }
       }
+      return true;
     }
 
     /*
@@ -838,8 +840,7 @@ public class UiBinderWriter {
      * playing with parameterized types. We're happy enough if the raw types
      * match, and rely on them to make sure the specific types really do work.
      */
-    if (possibleSupertypeElement != null
-        && !possibleSupertypeElement.getTypeParameters().isEmpty()) {
+    if (!AptUtil.isRaw(possibleSupertype)) {
       return isElementAssignableTo(elem, AptUtil.getTypeUtils().erasure(possibleSupertype));
     }
 

--- a/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/attributeparsers/AttributeParsers.java
+++ b/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/attributeparsers/AttributeParsers.java
@@ -162,8 +162,7 @@ public class AttributeParsers {
       if (t.getKind().isPrimitive()) {
         b.append(t.toString());
       } else {
-        // FIXME b.append(t.getParameterizedQualifiedSourceName());
-        b.append(AptUtil.asTypeElement(t).getQualifiedName().toString());
+        b.append(AptUtil.getParameterizedQualifiedSourceName(t));
       }
     }
     return b.toString();

--- a/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/elementparsers/BeanParser.java
+++ b/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/elementparsers/BeanParser.java
@@ -35,6 +35,8 @@ import java.util.Map.Entry;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeMirror;
 
 /**
@@ -165,7 +167,7 @@ public class BeanParser implements ElementParser {
         ExecutableElement setter = ownerFieldClass.getSetter(propertyName);
         if (setter != null) {
           String n = attribute.getName();
-          String value = elem.consumeAttributeWithDefault(n, null, getParamTypes(setter));
+          String value = elem.consumeAttributeWithDefault(n, null, getParamTypes(type, setter));
 
           if (value == null) {
             writer.die(elem, "Unable to parse %s.", attribute);
@@ -259,13 +261,12 @@ public class BeanParser implements ElementParser {
     return localizedValues;
   }
 
-  private TypeMirror[] getParamTypes(ExecutableElement setter) {
-    List<? extends VariableElement> params = setter.getParameters();
-    TypeMirror[] types = new TypeMirror[params.size()];
-    for (int i = 0; i < params.size(); i++) {
-      types[i] = params.get(i).asType();
-    }
-    return types;
+  private TypeMirror[] getParamTypes(TypeMirror ownerType, ExecutableElement setter) {
+    DeclaredType declaredType = AptUtil.asDeclaredType(ownerType);
+    TypeMirror declaredSetter = AptUtil.getTypeUtils().asMemberOf(declaredType, setter);
+    ExecutableType method = (ExecutableType) declaredSetter;
+
+    return method.getParameterTypes().toArray(new TypeMirror[0]);
   }
 
   private String initialCap(String propertyName) {

--- a/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/elementparsers/UiChildParser.java
+++ b/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/elementparsers/UiChildParser.java
@@ -98,7 +98,7 @@ public class UiChildParser implements ElementParser {
 
   private TypeMirror getFirstParamType(ExecutableElement method) {
     VariableElement variableElement = method.getParameters().get(0);
-    TypeElement typeElement = AptUtil.asTypeElement(variableElement);
+    TypeElement typeElement = AptUtil.asTypeElement(variableElement.asType());
     return typeElement != null ? typeElement.asType() : null;
   }
 

--- a/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/elementparsers/UiChildParser.java
+++ b/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/elementparsers/UiChildParser.java
@@ -37,8 +37,8 @@ import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeMirror;
 
 /**
- * Parses any children of widgets that use the {@link com.google.gwt.uibinder.client.UiChild
- * UIChild} annotation.
+ * Parses any children of widgets that use the {@code org.gwtproject.uibinder.client.UiChild}
+ * annotation.
  */
 public class UiChildParser implements ElementParser {
 


### PR DESCRIPTION
Fix to AptUtil.getAnnotationValues().   The APT AnnotationMirror does not have the default values, so grabbing from the associated type first and overlay with mirror values.