### PR TITLE
Add template path as comment to generated class file.

### DIFF
--- a/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/UiBinderProcessor.java
+++ b/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/UiBinderProcessor.java
@@ -150,6 +150,7 @@ public class UiBinderProcessor extends BaseProcessor {
     // Ensure that generated uibinder source is modified at least as often as synthesized .cssmap
     // resources, otherwise it would be possible to synthesize a modified .cssmap resource but fail
     // to retrigger the InlineClientBundleGenerator that processes it.
+    binderPrintWriter.println("// Template file: " + templatePath);
     binderPrintWriter.println("// .ui.xml template last modified: " + resource.getLastModified());
     Document doc = getW3cDoc(logger, resource);
 


### PR DESCRIPTION
This can help with identifying ui.xml file dependencies that could trigger a regeneration