### PR TITLE
Fix a creation section for gwt3 beans with non-empty constractors

### DIFF
--- a/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/elementparsers/BeanParser.java
+++ b/gwt-uibinder-processor/src/main/java/org/gwtproject/uibinder/processor/elementparsers/BeanParser.java
@@ -16,6 +16,7 @@
 package org.gwtproject.uibinder.processor.elementparsers;
 
 import org.gwtproject.uibinder.processor.AptUtil;
+import org.gwtproject.uibinder.processor.UiBinderApiPackage;
 import org.gwtproject.uibinder.processor.UiBinderContext;
 import org.gwtproject.uibinder.processor.UiBinderWriter;
 import org.gwtproject.uibinder.processor.XMLAttribute;
@@ -217,8 +218,13 @@ public class BeanParser implements ElementParser {
 //              factoryMethod.getName(),
 //              UiBinderWriter.asCommaSeparatedList(args));
 //        } else {
-        initializer = String.format("owner.%s(%s)", factoryMethod.getSimpleName(),
-            UiBinderWriter.asCommaSeparatedList(args));
+        if (UiBinderApiPackage.current().isGwtCreateSupported()) {
+          initializer = String.format("owner.%s(%s)", factoryMethod.getSimpleName(),
+                                      UiBinderWriter.asCommaSeparatedList(args));
+        } else {
+          initializer = String.format("new %s(%s)", factoryMethod.getEnclosingElement(),
+                                      UiBinderWriter.asCommaSeparatedList(args));
+        }
 //        }
         writer.setFieldInitializer(fieldName, initializer);
       } else { // Annotated Constructor


### PR DESCRIPTION
for classes with

   @UiConstructor
    public Column(String size) {
        this.setSize(size);
    }
uibinder generates this call:

    private org.gwtbootstrap3.client.ui.Column build_f_Column2() {
      // Creation section.
      final org.gwtbootstrap3.client.ui.Column f_Column2 = owner.<init>("XS_12");
      // Setup section.
      f_Column2.add(get_f_PageHeader3());
      return f_Column2;
    }

Any ideas ?
